### PR TITLE
Update the patterns examples to use C# 9 features

### DIFF
--- a/code/pattern-matching-2.cs
+++ b/code/pattern-matching-2.cs
@@ -2,7 +2,7 @@
 var result = item switch
 {
     Square s => Handle(s),
-    Circle c when c.Radius < 10 => HandleUnder10(c),
+    Circle { Radius: < 10 } c => HandleUnder10(c),
     Circle { Radius: 20 } c => Handle20(c),
     Circle c => Handle(c),
     _ => throw new Exception("Unknown shape")
@@ -11,9 +11,9 @@ var result = item switch
 // Same with if statements
 if (item is Square s)
 { }
-else if (item is Circle c && c.Radius < 10)
+else if (item is Circle { Radius: < 10 })
 { }
-else if (item is Circle { Radius: 20} c)
+else if (item is Circle { Radius: 20 })
 { }
 else if (item is Circle ci)
 { }

--- a/code/pattern-matching.cs
+++ b/code/pattern-matching.cs
@@ -1,3 +1,4 @@
+// Pre C#-9
 var nb = 42;
 var text = nb switch
 {
@@ -6,5 +7,15 @@ var text = nb switch
     int i when i < 100 => "double digits",
     int i when i < 1000 => "triple digits",
     _ => "four or more digits"
+};
+
+// With C# 9 relational and conjunctive patterns
+var nb = 42;
+var text = nb switch
+{
+    < 10 => "single digit",
+    10 or (>= 11 and < 100) => "double digits",
+    < 1000 => "triple digits",
+    _ => "for or more digits",
 };
 // double digits


### PR DESCRIPTION
The patterns examples were using `when` guards instead of relational operators, so I went and updated them to use the features from C# 9.