### PR TITLE
Use Kotlin Triple over data class

### DIFF
--- a/code/tuple-return.kt
+++ b/code/tuple-return.kt
@@ -1,8 +1,5 @@
-// Kotlin doesn't have tuples, use data classes
-data class GasPrices(val a: Double, val b: Double, val c: Double)
+fun getGasPrices() = Triple(3.59, 3.69, 3.79)
 
-fun getGasPrices() = GasPrices(3.59, 3.69, 3.79)
+val prices = getGasPrices()
 
-val prices = getGasPrices();
-
-val (a, b, c) = getGasPrices();
+val (a, b, c) = getGasPrices()

--- a/index.html
+++ b/index.html
@@ -251,14 +251,11 @@ val result = transform("hello", { x -> x.toUpperCase() })
 val result2 = transform("hello") { x -> x.toUpperCase() }</code></pre></div><div class="card"><div class="lang">C#</div><pre class="code"><code>string Transform(string initial, Func&lt;string, string> f) => f(initial);
 
 var result = Transform("hello", x => x.ToUpper());
-// HELLO</code></pre></div></div></div><div class="case"><div class="name">Tuple Return</div><div class="pair"><div class="card"><div class="lang">Kotlin</div><pre class="code"><code>// Kotlin doesn't have tuples, use data classes
-data class GasPrices(val a: Double, val b: Double, val c: Double)
+// HELLO</code></pre></div></div></div><div class="case"><div class="name">Tuple Return</div><div class="pair"><div class="card"><div class="lang">Kotlin</div><pre class="code"><code>fun getGasPrices() = Triple(3.59, 3.69, 3.79)
 
-fun getGasPrices() = GasPrices(3.59, 3.69, 3.79)
+val prices = getGasPrices()
 
-val prices = getGasPrices();
-
-val (a, b, c) = getGasPrices();</code></pre></div><div class="card"><div class="lang">C#</div><pre class="code"><code>(double a, double b, double c) GetGasPrices() => (3.59, 3.69, 3.79);
+val (a, b, c) = getGasPrices()</code></pre></div><div class="card"><div class="lang">C#</div><pre class="code"><code>(double a, double b, double c) GetGasPrices() => (3.59, 3.69, 3.79);
 
 var result = GetGasPrices();
 


### PR DESCRIPTION
In Kotlin, a Tuple is called a [Triple](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-triple/-init-.html). There's no need for a custom data class here. Also, the use of semicolons here seems to be a typo.

Before:
```kotlin
// Kotlin doesn't have tuples, use data classes
data class GasPrices(val a: Double, val b: Double, val c: Double)

fun getGasPrices() = GasPrices(3.59, 3.69, 3.79)

val prices = getGasPrices();

val (a, b, c) = getGasPrices();
```

After:
```kotlin
fun getGasPrices() = Triple(3.59, 3.69, 3.79)

val prices = getGasPrices()

val (a, b, c) = getGasPrices()
```