### PR TITLE
Use Kotlin function reference in HOF example

### DIFF
--- a/code/hof-parameter.kt
+++ b/code/hof-parameter.kt
@@ -1,7 +1,8 @@
-fun transform(initial: String, f: (String) -> String) = f(initial)
+fun transform(initial: String, transformer: (String) -> String) = transformer(initial)
 
-val result = transform("hello", { x -> x.toUpperCase() })
+// Function reference
+val result = transform("hello", String::uppercase)
 // HELLO
 
 // Trailing lambda can be placed outside the parentheses
-val result2 = transform("hello") { x -> x.toUpperCase() }
+val result2 = transform("hello") { it.uppercase() }

--- a/index.html
+++ b/index.html
@@ -242,13 +242,14 @@ var result = increment(7);
 
 // MakeIncrementer can also be written in a shorter way:
 Func&lt;int, int> MakeIncrementer() => i => 1 + i;
-</code></pre></div></div></div><div class="case"><div class="name">HOF - Function as Parameter</div><div class="pair"><div class="card"><div class="lang">Kotlin</div><pre class="code"><code>fun transform(initial: String, f: (String) -> String) = f(initial)
+</code></pre></div></div></div><div class="case"><div class="name">HOF - Function as Parameter</div><div class="pair"><div class="card"><div class="lang">Kotlin</div><pre class="code"><code>fun transform(initial: String, transformer: (String) -> String) = transformer(initial)
 
-val result = transform("hello", { x -> x.toUpperCase() })
+// Function reference
+val result = transform("hello", String::uppercase)
 // HELLO
 
 // Trailing lambda can be placed outside the parentheses
-val result2 = transform("hello") { x -> x.toUpperCase() }</code></pre></div><div class="card"><div class="lang">C#</div><pre class="code"><code>string Transform(string initial, Func&lt;string, string> f) => f(initial);
+val result2 = transform("hello") { it.uppercase() }</code></pre></div><div class="card"><div class="lang">C#</div><pre class="code"><code>string Transform(string initial, Func&lt;string, string> f) => f(initial);
 
 var result = Transform("hello", x => x.ToUpper());
 // HELLO</code></pre></div></div></div><div class="case"><div class="name">Tuple Return</div><div class="pair"><div class="card"><div class="lang">Kotlin</div><pre class="code"><code>// Kotlin doesn't have tuples, use data classes


### PR DESCRIPTION
Having a lambda inside a function's parantheses isn't hugely idiomatic in Kotlin.

Therefore, you can either use a function reference or have it outside the parantheses:
- `transform(String::uppercase)`
- `transform { it.uppercase() }`

You don't need to specify a variable name when using a lambda as `it` is implicitly provided.

[`toUpperCase()`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/to-upper-case.html) was deprecated in Kotlin 1.5.0 in favour of [`uppercase()`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/uppercase.html).

Before:
```kotlin
fun transform(initial: String, f: (String) -> String) = f(initial)

val result = transform("hello", { x -> x.toUpperCase() })
// HELLO

// Trailing lambda can be placed outside the parentheses
val result2 = transform("hello") { x -> x.toUpperCase() }
```

After:
```kotlin
fun transform(initial: String, transformer: (String) -> String) = transformer(initial)

// Function reference
val result = transform("hello", String::uppercase)
// HELLO

// Trailing lambda can be placed outside the parentheses
val result2 = transform("hello") { it.uppercase() }
```

You can test this code [here](https://pl.kotl.in/TtDMdEFNd) on the Kotlin Playground.