### PR TITLE
Make Kotlin collection example clearer

### DIFF
--- a/code/collections.kt
+++ b/code/collections.kt
@@ -7,11 +7,9 @@ var datas = listOf(
 )
 
 var avgs = datas
-            .filter { it.value > -50.0 }
-            .groupBy { it.location }
-            .map { g -> 
-                Location(g.key, 
-                         g.value.map { it.value }.average()) }
-
+    .filter { it.value > -50.0 }
+    .groupBy(SensorData::location)
+    .map { Location(it.key, it.value.map(SensorData::value).average()) }
+    
 // (location=A, value=3.0)
 // (location=B, value=11.95)

--- a/code/collections.kt
+++ b/code/collections.kt
@@ -1,4 +1,4 @@
-var datas = listOf(
+val datas = listOf(
     SensorData(1, "A", 2.89),
     SensorData(2, "B", 12.01),
     SensorData(3, "B", 11.89),
@@ -6,7 +6,7 @@ var datas = listOf(
     SensorData(5, "A", -456.0)
 )
 
-var avgs = datas
+val avgs = datas
     .filter { it.value > -50.0 }
     .groupBy(SensorData::location)
     .map { Location(it.key, it.value.map(SensorData::value).average()) }

--- a/index.html
+++ b/index.html
@@ -407,11 +407,9 @@ var multiplied = numbers.Select(e => 3 * e);
 )
 
 var avgs = datas
-            .filter { it.value > -50.0 }
-            .groupBy { it.location }
-            .map { g -> 
-                Location(g.key, 
-                         g.value.map { it.value }.average()) }
+    .filter { it.value > -50.0 }
+    .groupBy(SensorData::location)
+    .map { Location(it.key, it.value.map(SensorData::value).average()) }
 
 // (location=A, value=3.0)
 // (location=B, value=11.95)</code></pre></div><div class="card"><div class="lang">C#</div><pre class="code"><code>var datas = new List&lt;SensorData> 

--- a/index.html
+++ b/index.html
@@ -398,7 +398,7 @@ val multiplied = numbers.map { 3 * it }
 var multiplied = numbers.Select(e => 3 * e);
 // [ 60, 57, 21, 36 ]</code></pre></div></div></div><div class="case"><div class="name">Sort</div><div class="pair"><div class="card"><div class="lang">Kotlin</div><pre class="code"><code>val ordered = listOf(1, 5, 3, 12, 2).sorted()
 // [ 1, 2, 3, 5, 12 ]</code></pre></div><div class="card"><div class="lang">C#</div><pre class="code"><code>var ordered = new[] { 1, 5, 3, 12, 2 }.OrderBy(i => i);
-// [ 1, 2, 3, 5, 12 ]</code></pre></div></div></div><div class="case"><div class="name">Filter / GroupBy / Average</div><div class="pair"><div class="card"><div class="lang">Kotlin</div><pre class="code"><code>var datas = listOf(
+// [ 1, 2, 3, 5, 12 ]</code></pre></div></div></div><div class="case"><div class="name">Filter / GroupBy / Average</div><div class="pair"><div class="card"><div class="lang">Kotlin</div><pre class="code"><code>val datas = listOf(
     SensorData(1, "A", 2.89),
     SensorData(2, "B", 12.01),
     SensorData(3, "B", 11.89),
@@ -406,7 +406,7 @@ var multiplied = numbers.Select(e => 3 * e);
     SensorData(5, "A", -456.0)
 )
 
-var avgs = datas
+val avgs = datas
     .filter { it.value > -50.0 }
     .groupBy(SensorData::location)
     .map { Location(it.key, it.value.map(SensorData::value).average()) }


### PR DESCRIPTION
This pull request changes the Filter / GroupBy / Average example for Kotlin to be a bit clearer and more idiomatic.

Before:
```kotlin
var avgs = datas
            .filter { it.value > -50.0 }
            .groupBy { it.location }
            .map { g -> 
                Location(g.key, 
                         g.value.map { it.value }.average()) }
```
After:
```kotlin
val avgs = datas
    .filter { it.value > -50.0 }
    .groupBy(SensorData::location)
    .map { Location(it.key, it.value.map(SensorData::value).average()) }
```

You can test this code [here](https://pl.kotl.in/-19Wl2-As) on the Kotlin Playground.